### PR TITLE
removed fold related keymaps

### DIFF
--- a/ftdetect/http.lua
+++ b/ftdetect/http.lua
@@ -1,21 +1,5 @@
 vim.filetype.add({ extension = { http = "http" } })
 
-vim.keymap.set("n", "zz", function()
-	-- toggle folding
-	if vim.opt.foldmethod._value ~= "expr" then
-		vim.cmd("setlocal foldmethod=expr")
-		vim.cmd("setlocal foldexpr=v:lua.foldexpr(v:lnum)")
-	else
-		vim.cmd("setlocal foldmethod=manual")
-		vim.cmd("normal zE")
-	end
-
-	-- vim.cmd("setlocal foldtext=~~~")
-end, { silent = true, desc = "[zz] activate folding" })
-
-vim.keymap.set("n", "+", "zo")
-vim.keymap.set("n", "-", "zc")
-
 -- Reset diagnostic by changing the file
 vim.api.nvim_create_augroup("RestyDiagnostic", { clear = true })
 -- text change in Insert and Normal mode => diagnostic reset


### PR DESCRIPTION
The plugin creates some keymaps regarding folds that are associated with generic keys that may be assigned to something else on the user's config (in addition to the fact that they are very arbitrary). These keymaps are not mentioned anywhere in the readme, and thus this feels like the wrong place for them. 

Feel free to do what you want with this PR: it is also arbitrary to remove the keymaps, even if they weren't standard in the first place, I forked to remove them for my config and just thought to open a PR either way.
